### PR TITLE
chore: define `try_new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Changed
+- `Array::new` and `Single::new` now panic when the requirements are not fulfilled.
+- Previous `Array::new` and `Single::new` are renamed to `Array::try_new` and `Single::try_new` respectively.
 
 ## 0.2.0 - 2021-01-26
 ### Changed

--- a/src/array.rs
+++ b/src/array.rs
@@ -28,9 +28,7 @@ use core::{fmt, hash::Hash, marker::PhantomData, mem, ptr};
 ///
 /// // Create an accessor to the array at the physical address 0x1000 that has 10 elements
 /// // of i32 type.
-/// let mut a = unsafe {
-///     accessor::Array::<u32, M>::new(0x1000, 10, mapper).expect("Failed to create an accessor.")
-/// };
+/// let mut a = unsafe { accessor::Array::<u32, M>::new(0x1000, 10, mapper) };
 ///
 /// // Read the 3rd element of the array.
 /// a.read_at(3);

--- a/src/array.rs
+++ b/src/array.rs
@@ -73,7 +73,7 @@ where
     /// This method may return an error.
     /// - [`Error::NotAligned`] - `phys_base` is not aligned as the type `T` requires.
     /// - [`Error::EmptyArray`] - `len == 0`
-    pub unsafe fn new(phys_base: usize, len: usize, mapper: M) -> Result<Self, Error> {
+    pub unsafe fn try_new(phys_base: usize, len: usize, mapper: M) -> Result<Self, Error> {
         if len == 0 {
             Err(Error::EmptyArray)
         } else if super::is_aligned::<T>(phys_base) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,7 @@
 //! }
 //!
 //! // Create an accessor to an i32 value at the physical address 0x1000.
-//! let mut a = unsafe {
-//!     accessor::Single::<i32, M>::new(0x1000, M).expect("Failed to create an accessor.")
-//! };
+//! let mut a = unsafe { accessor::Single::<i32, M>::new(0x1000, M) };
 //!
 //! // Read a value.
 //! a.read();
@@ -33,9 +31,7 @@
 //! a.write(3);
 //!
 //! // Create an accessor to an array at the physical address 0x2000 of the type i32 that has 5 elements.
-//! let mut arr = unsafe {
-//!     accessor::Array::<i32, M>::new(0x2000, 5, M).expect("Failed to create an accessor.")
-//! };
+//! let mut arr = unsafe { accessor::Array::<i32, M>::new(0x2000, 5, M) };
 //!
 //! // Read the 2nd element.
 //! arr.read_at(2);

--- a/src/single.rs
+++ b/src/single.rs
@@ -68,7 +68,7 @@ where
     ///
     /// This method may return a [`Error::NotAligned`] error if `phys_base` is not aligned as the
     /// type `T` requires.
-    pub unsafe fn new(phys_base: usize, mapper: M) -> Result<Self, Error> {
+    pub unsafe fn try_new(phys_base: usize, mapper: M) -> Result<Self, Error> {
         if super::is_aligned::<T>(phys_base) {
             Ok(Self::new_aligned(phys_base, mapper))
         } else {

--- a/src/single.rs
+++ b/src/single.rs
@@ -25,9 +25,7 @@ use core::{fmt, hash::Hash, marker::PhantomData, mem, ptr};
 /// let mapper = M;
 ///
 /// // Create an accessor to the i32 value at the physical address 0x1000.
-/// let mut a = unsafe {
-///     accessor::Single::<i32, M>::new(0x1000, mapper).expect("Failed to create an accessor.")
-/// };
+/// let mut a = unsafe { accessor::Single::<i32, M>::new(0x1000, mapper) };
 ///
 /// // Read a value.
 /// a.read();


### PR DESCRIPTION
- chore: rename to `try_new`
- feat: reimplement `Single::new` and `Array::new`
- docs: fix
- chore: add a changelog

`new` methods now panic if the requirements are not fulfilled.

Fixes: #12 but `error::Error` is not removed because `try_new` may return it.