### PR TITLE
chore: ignore `*.swp` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 tags
+*.swp


### PR DESCRIPTION
bors r+
