### PR TITLE
chore: remove `rustfmt.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Bors is no longer used for merging PRs ([#20](https://github.com/toku-sa-n/accessor/pull/20)).
 - Tests on CI are executed on stable Rust, not the nightly one ([#21](https://github.com/toku-sa-n/accessor/pull/21)).
+- `rustfmt.toml` is deleted so that `cargo fmt` works on stable Rust ([#23](https://github.com/toku-sa-n/accessor/pull/23)).
 
 ### Fixed
 - Clippy warnings are fixed ([#19](https://github.com/toku-sa-n/accessor/pull/19)).

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2018"
-merge_imports = true
-format_code_in_doc_comments = true


### PR DESCRIPTION
To remove nightly-only style settings.
