### PR TITLE
chore: deprecate methods without "volatile"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Tests on CI are executed on stable Rust, not the nightly one ([#21](https://github.com/toku-sa-n/accessor/pull/21)).
 - Multiple lints that are allowed by default are now denied ([#22](https://github.com/toku-sa-n/accessor/pull/22)).
 - `rustfmt.toml` is deleted so that `cargo fmt` works on stable Rust ([#23](https://github.com/toku-sa-n/accessor/pull/23)).
+- Methods that are not ended with "volatile" like `Single::read` are now deprecated. Use methods ending with "volatile" like `Single::read_volatile` ([#24](https://github.com/toku-sa-n/accessor/pull/24)).
 
 ### Fixed
 - Clippy warnings are fixed ([#19](https://github.com/toku-sa-n/accessor/pull/19)).

--- a/src/array.rs
+++ b/src/array.rs
@@ -31,13 +31,13 @@ use core::{fmt, hash::Hash, marker::PhantomData, mem, ptr};
 /// let mut a = unsafe { accessor::Array::<u32, M>::new(0x1000, 10, mapper) };
 ///
 /// // Read the 3rd element of the array.
-/// a.read_at(3);
+/// a.read_volatile_at(3);
 ///
 /// // Write 42 as the 5th element of the array.
-/// a.write_at(5, 42);
+/// a.write_volatile_at(5, 42);
 ///
 /// // Update the 0th element.
-/// a.update_at(0, |v| {
+/// a.update_volatile_at(0, |v| {
 ///     *v *= 2;
 /// });
 /// ```
@@ -118,11 +118,17 @@ where
     /// # Panics
     ///
     /// This method will panic if `i >= self.len()`
-    pub fn read_at(&self, i: usize) -> T {
+    pub fn read_volatile_at(&self, i: usize) -> T {
         assert!(i < self.len());
 
         // SAFETY: `Accessor::new_array` ensures that `self.addr(i)` is aligned properly.
         unsafe { ptr::read_volatile(self.addr(i) as *const _) }
+    }
+
+    /// Alias of [`Array::read_volatile_at`].
+    #[deprecated(note = "use `read_volatile_at`")]
+    pub fn read_at(&self, i: usize) -> T {
+        self.read_volatile_at(i)
     }
 
     /// Writes `v` as the `i`th element to the address that the accessor points to.
@@ -130,7 +136,7 @@ where
     /// # Panics
     ///
     /// This method will panic if `i >= self.len()`
-    pub fn write_at(&mut self, i: usize, v: T) {
+    pub fn write_volatile_at(&mut self, i: usize, v: T) {
         assert!(i < self.len());
 
         // SAFETY: `Accessor::new_array` ensures that `self.addr(i)` is aligned properly.
@@ -139,14 +145,29 @@ where
         }
     }
 
+    /// Alias of [`Array::write_volatile_at`].
+    #[deprecated(note = "use `write_volatile_at`")]
+    pub fn write_at(&mut self, i: usize, v: T) {
+        self.write_volatile_at(i, v)
+    }
+
     /// Updates the `i`th element that the accessor points by reading it, modifying it, and writing it.
+    pub fn update_volatile_at<U>(&mut self, i: usize, f: U)
+    where
+        U: FnOnce(&mut T),
+    {
+        let mut v = self.read_volatile_at(i);
+        f(&mut v);
+        self.write_volatile_at(i, v);
+    }
+
+    /// Alias of [`Array::update_volatile_at`].
+    #[deprecated(note = "use `update_volatile_at`")]
     pub fn update_at<U>(&mut self, i: usize, f: U)
     where
         U: FnOnce(&mut T),
     {
-        let mut v = self.read_at(i);
-        f(&mut v);
-        self.write_at(i, v);
+        self.update_volatile_at(i, f)
     }
 
     /// Returns the length of the array.
@@ -250,7 +271,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.i < self.a.len() {
-            let t = self.a.read_at(self.i);
+            let t = self.a.read_volatile_at(self.i);
             self.i += 1;
             Some(t)
         } else {

--- a/src/array.rs
+++ b/src/array.rs
@@ -126,7 +126,7 @@ where
     }
 
     /// Alias of [`Array::read_volatile_at`].
-    #[deprecated(note = "use `read_volatile_at`")]
+    #[deprecated(since = "0.3.1", note = "use `read_volatile_at`")]
     pub fn read_at(&self, i: usize) -> T {
         self.read_volatile_at(i)
     }
@@ -146,7 +146,7 @@ where
     }
 
     /// Alias of [`Array::write_volatile_at`].
-    #[deprecated(note = "use `write_volatile_at`")]
+    #[deprecated(since = "0.3.1", note = "use `write_volatile_at`")]
     pub fn write_at(&mut self, i: usize, v: T) {
         self.write_volatile_at(i, v)
     }
@@ -162,7 +162,7 @@ where
     }
 
     /// Alias of [`Array::update_volatile_at`].
-    #[deprecated(note = "use `update_volatile_at`")]
+    #[deprecated(since = "0.3.1", note = "use `update_volatile_at`")]
     pub fn update_at<U>(&mut self, i: usize, f: U)
     where
         U: FnOnce(&mut T),

--- a/src/single.rs
+++ b/src/single.rs
@@ -110,7 +110,7 @@ where
     }
 
     /// Alias of [`Single::read_volatile`].
-    #[deprecated(note = "use `read_volatile`")]
+    #[deprecated(since = "0.3.1", note = "use `read_volatile`")]
     pub fn read(&self) -> T {
         self.read_volatile()
     }
@@ -124,7 +124,7 @@ where
     }
 
     /// Alias of [`Single::write_volatile`].
-    #[deprecated(note = "use `write_volatile`")]
+    #[deprecated(since = "0.3.1", note = "use `write_volatile`")]
     pub fn write(&mut self, v: T) {
         self.write_volatile(v);
     }
@@ -144,7 +144,7 @@ where
     }
 
     /// Alias of [`Single::update_volatile`].
-    #[deprecated(note = "use `update_volatile`")]
+    #[deprecated(since = "0.3.1", note = "use `update_volatile`")]
     pub fn update<U>(&mut self, f: U)
     where
         U: FnOnce(&mut T),

--- a/src/single.rs
+++ b/src/single.rs
@@ -28,13 +28,13 @@ use core::{fmt, hash::Hash, marker::PhantomData, mem, ptr};
 /// let mut a = unsafe { accessor::Single::<i32, M>::new(0x1000, mapper) };
 ///
 /// // Read a value.
-/// a.read();
+/// a.read_volatile();
 ///
 /// // Write 42.
-/// a.write(42);
+/// a.write_volatile(42);
 ///
 /// // Update the value.
-/// a.update(|v| {
+/// a.update_volatile(|v| {
 ///     *v *= 2;
 /// });
 /// ```
@@ -104,17 +104,29 @@ where
     }
 
     /// Reads a value from the address that the accessor points to.
-    pub fn read(&self) -> T {
+    pub fn read_volatile(&self) -> T {
         // SAFETY: `Accessor::new` ensures that `self.virt` is aligned properly.
         unsafe { ptr::read_volatile(self.virt as *const _) }
     }
 
+    /// Alias of [`Single::read_volatile`].
+    #[deprecated(note = "use `read_volatile`")]
+    pub fn read(&self) -> T {
+        self.read_volatile()
+    }
+
     /// Writes a value to the address that the accessor points to.
-    pub fn write(&mut self, v: T) {
+    pub fn write_volatile(&mut self, v: T) {
         // SAFETY: `Accessor::new` ensures that `self.virt` is aligned properly.
         unsafe {
             ptr::write_volatile(self.virt as *mut _, v);
         }
+    }
+
+    /// Alias of [`Single::write_volatile`].
+    #[deprecated(note = "use `write_volatile`")]
+    pub fn write(&mut self, v: T) {
+        self.write_volatile(v);
     }
 
     /// Updates a value that the accessor points by reading it, modifying it, and writing it.
@@ -122,13 +134,22 @@ where
     /// Note that some MMIO regions (e.g. the Command Ring Pointer field of the Command
     /// Ring Control Register of the xHCI) may return 0 regardless of the actual values of the
     /// fields. For these regions, this operation should be called only once.
+    pub fn update_volatile<U>(&mut self, f: U)
+    where
+        U: FnOnce(&mut T),
+    {
+        let mut v = self.read_volatile();
+        f(&mut v);
+        self.write_volatile(v);
+    }
+
+    /// Alias of [`Single::update_volatile`].
+    #[deprecated(note = "use `update_volatile`")]
     pub fn update<U>(&mut self, f: U)
     where
         U: FnOnce(&mut T),
     {
-        let mut v = self.read();
-        f(&mut v);
-        self.write(v);
+        self.update_volatile(f);
     }
 }
 impl<T, M> fmt::Debug for Single<T, M>
@@ -137,7 +158,7 @@ where
     M: Mapper,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.read())
+        write!(f, "{:?}", self.read_volatile())
     }
 }
 impl<T, M> PartialEq for Single<T, M>
@@ -146,7 +167,7 @@ where
     M: Mapper,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.read().eq(&other.read())
+        self.read_volatile().eq(&other.read_volatile())
     }
 }
 impl<T, M> Eq for Single<T, M>
@@ -161,7 +182,7 @@ where
     M: Mapper,
 {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.read().partial_cmp(&other.read())
+        self.read_volatile().partial_cmp(&other.read_volatile())
     }
 }
 impl<T, M> Ord for Single<T, M>
@@ -170,7 +191,7 @@ where
     M: Mapper,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.read().cmp(&other.read())
+        self.read_volatile().cmp(&other.read_volatile())
     }
 }
 impl<T, M> Hash for Single<T, M>
@@ -179,7 +200,7 @@ where
     M: Mapper,
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.read().hash(state);
+        self.read_volatile().hash(state);
     }
 }
 impl<T, M> Drop for Single<T, M>


### PR DESCRIPTION
Names without "volatile" are confusing.
