### PR TITLE
chore: remove `Copy` trait bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - `no_run` attribute is added to the code example in `README.md` to avoid a compile error ([#38]).
+- `Copy` trait bound is removed from `array::Generic` and `single::Generic ([#37]).
 
 ## [0.3.2] - 2021-08-04
 ### Added
@@ -63,6 +64,7 @@
 - Initial version.
 
 [#38]: https://github.com/toku-sa-n/accessor/pull/38
+[#37]: https://github.com/toku-sa-n/accessor/pull/37
 [#34]: https://github.com/toku-sa-n/accessor/pull/34
 [#33]: https://github.com/toku-sa-n/accessor/pull/33
 [#32]: https://github.com/toku-sa-n/accessor/pull/32

--- a/src/array.rs
+++ b/src/array.rs
@@ -26,6 +26,9 @@ pub type WriteOnly<T, M> = Generic<T, M, marker::WriteOnly>;
 ///
 /// When accessing to an element of the array, the index starts from 0.
 ///
+/// `T` does not need to implement [`Copy`]. However, be careful that [`Generic::read_volatile_at`]
+/// creates and [`Generic::write_volatile_at`] writes a bitwise copy of a value.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -62,7 +65,6 @@ pub type WriteOnly<T, M> = Generic<T, M, marker::WriteOnly>;
 /// ```
 pub struct Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {
@@ -75,7 +77,6 @@ where
 #[allow(clippy::len_without_is_empty)] // Array is never empty.
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {
@@ -151,7 +152,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {
@@ -175,7 +175,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Writable,
 {
@@ -201,7 +200,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable + Writable,
 {
@@ -226,7 +224,7 @@ where
 }
 impl<T, M, A> fmt::Debug for Generic<T, M, A>
 where
-    T: Copy + fmt::Debug,
+    T: fmt::Debug,
     M: Mapper,
     A: Readable,
 {
@@ -236,7 +234,7 @@ where
 }
 impl<T, M, A> PartialEq for Generic<T, M, A>
 where
-    T: Copy + PartialEq,
+    T: PartialEq,
     M: Mapper,
     A: Readable,
 {
@@ -249,14 +247,14 @@ where
 }
 impl<T, M, A> Eq for Generic<T, M, A>
 where
-    T: Copy + Eq,
+    T: Eq,
     M: Mapper,
     A: Readable,
 {
 }
 impl<T, M, A> Hash for Generic<T, M, A>
 where
-    T: Copy + Hash,
+    T: Hash,
     M: Mapper,
     A: Readable,
 {
@@ -268,7 +266,6 @@ where
 }
 impl<'a, T, M, A> IntoIterator for &'a Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {
@@ -281,7 +278,6 @@ where
 }
 impl<T, M, A> Drop for Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {
@@ -294,7 +290,6 @@ where
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Iter<'a, T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {
@@ -303,7 +298,6 @@ where
 }
 impl<'a, T, M, A> Iter<'a, T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {
@@ -313,7 +307,6 @@ where
 }
 impl<'a, T, M, A> Iterator for Iter<'a, T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {

--- a/src/single.rs
+++ b/src/single.rs
@@ -24,6 +24,9 @@ pub type WriteOnly<T, M> = Generic<T, M, marker::WriteOnly>;
 
 /// An accessor to read, modify, and write a single value of memory.
 ///
+/// `T` does not need to implement [`Copy`]. However, be careful that [`Generic::read_volatile`]
+/// creates and [`Generic::write_volatile`] writes a bitwise copy of a value.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -60,7 +63,6 @@ pub type WriteOnly<T, M> = Generic<T, M, marker::WriteOnly>;
 /// ```
 pub struct Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {
@@ -72,7 +74,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {
@@ -129,7 +130,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable,
 {
@@ -147,7 +147,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Writable,
 {
@@ -167,7 +166,6 @@ where
 }
 impl<T, M, A> Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: Readable + Writable,
 {
@@ -196,7 +194,7 @@ where
 }
 impl<T, M, A> fmt::Debug for Generic<T, M, A>
 where
-    T: Copy + fmt::Debug,
+    T: fmt::Debug,
     M: Mapper,
     A: Readable,
 {
@@ -206,7 +204,7 @@ where
 }
 impl<T, M, A> PartialEq for Generic<T, M, A>
 where
-    T: Copy + PartialEq,
+    T: PartialEq,
     M: Mapper,
     A: Readable,
 {
@@ -216,14 +214,14 @@ where
 }
 impl<T, M, A> Eq for Generic<T, M, A>
 where
-    T: Copy + Eq,
+    T: Eq,
     M: Mapper,
     A: Readable,
 {
 }
 impl<T, M, A> PartialOrd for Generic<T, M, A>
 where
-    T: Copy + PartialOrd,
+    T: PartialOrd,
     M: Mapper,
     A: Readable,
 {
@@ -233,7 +231,7 @@ where
 }
 impl<T, M, A> Ord for Generic<T, M, A>
 where
-    T: Copy + Ord,
+    T: Ord,
     M: Mapper,
     A: Readable,
 {
@@ -243,7 +241,7 @@ where
 }
 impl<T, M, A> Hash for Generic<T, M, A>
 where
-    T: Copy + Hash,
+    T: Hash,
     M: Mapper,
     A: Readable,
 {
@@ -253,7 +251,6 @@ where
 }
 impl<T, M, A> Drop for Generic<T, M, A>
 where
-    T: Copy,
     M: Mapper,
     A: AccessorTypeSpecifier,
 {


### PR DESCRIPTION
This commit removes the `Copy` trait boundary from `array::Generic` and  `single::Generic`.
The official documentation of `Copy` says:

>Types whose values can be duplicated simply by copying bits.

However, a type that can implement `Copy` may not implement it for some reason. (e.g., too high copy cost, to avoid copying where the user intended the borrowing, etc.) Strictly speaking, these types should have a `Copy` trait boundary, but I have decided to remove the trait boundary to handle such types.
