### PR TITLE
fix(README.md): add `no_run` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- `no_run` attribute is added to the code example in `README.md` to avoid a compile error ([#38]).
 
 ## [0.3.2] - 2021-08-04
 ### Added
@@ -60,6 +62,7 @@
 ### Added
 - Initial version.
 
+[#38]: https://github.com/toku-sa-n/accessor/pull/38
 [#34]: https://github.com/toku-sa-n/accessor/pull/34
 [#33]: https://github.com/toku-sa-n/accessor/pull/33
 [#32]: https://github.com/toku-sa-n/accessor/pull/32

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The accessed type must implement [`Copy`] because reading and writing values nee
 
 This crate is `#[no_std]` compatible.
 
-```rust
+```rust,no_run
 use accessor::mapper::Mapper;
 use core::num::NonZeroUsize;
 


### PR DESCRIPTION
To avoid a runtime error caused by `todo!()`.
