### PR TITLE
Remove byte size field from accessor

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -145,10 +145,6 @@ where
     fn addr(&self, i: usize) -> usize {
         self.virt + mem::size_of::<T>() * i
     }
-
-    fn bytes(&self) -> usize {
-        mem::size_of::<T>() * self.len
-    }
 }
 impl<T, M, A> Generic<T, M, A>
 where
@@ -282,7 +278,8 @@ where
     A: AccessorTypeSpecifier,
 {
     fn drop(&mut self) {
-        self.mapper.unmap(self.virt, self.bytes());
+        let bytes = mem::size_of::<T>() * self.len;
+        self.mapper.unmap(self.virt, bytes);
     }
 }
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -67,7 +67,6 @@ where
     A: AccessorTypeSpecifier,
 {
     virt: usize,
-    bytes: usize,
     _marker: PhantomData<T>,
     _readable_writable: PhantomData<A>,
     mapper: M,
@@ -97,7 +96,6 @@ where
 
         Self {
             virt,
-            bytes,
             _marker: PhantomData,
             _readable_writable: PhantomData,
             mapper,
@@ -255,6 +253,7 @@ where
     A: AccessorTypeSpecifier,
 {
     fn drop(&mut self) {
-        self.mapper.unmap(self.virt, self.bytes);
+        let bytes = mem::size_of::<T>();
+        self.mapper.unmap(self.virt, bytes);
     }
 }


### PR DESCRIPTION
For a single-element accessor, its size can be determined with const function `mem::size_of::<T>()`. No need to store it in a field.